### PR TITLE
Improve graph layout and add custom tooltips

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -343,6 +343,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
                 <SampleGraph
                   domain={currentDomain}
                   refreshTrigger={refreshTrigger}
+                  theme={theme}
                 />
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- make Graphviz chain display vertically by default
- show graph slightly higher in the card
- implement custom SVG tooltip handling with theme-aware styling
- pass current theme to `SampleGraph`

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684960617ae4832ea5a76cb8005cefdf