### PR TITLE
Adjust graph layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -339,7 +339,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
           {/*rendering card */}
           <div className="relative">
             <Card className="w-full bg-card border-border">
-              <CardContent className="relative px-10 py-10 lg:px-14 lg:py-14 flex justify-center overflow-auto">
+              <CardContent className="relative px-6 py-6 lg:px-8 lg:py-8 flex justify-center overflow-auto">
                 <SampleGraph
                   domain={currentDomain}
                   refreshTrigger={refreshTrigger}

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -142,20 +142,18 @@ const SampleGraph = ({ domain, refreshTrigger, theme }) => {
   }
 
   return (
-    <div className="w-full overflow-auto flex flex-col items-center">
+    <div className="w-full overflow-auto flex flex-col gap-4">
       {summary && (
-        <div className="mb-4 text-center">
-          <h2 className="font-semibold text-lg text-foreground">
-            {domain}
-          </h2>
+        <div className="text-left">
+          <h2 className="font-semibold text-lg text-foreground">{domain}</h2>
           <p className="text-sm text-muted-foreground">
-            Levels: {summary.total_levels} • Signed: {summary.signed_levels}
-            • Breaks: {summary.chain_breaks?.length || 0}
+            Levels: {summary.total_levels} • Signed: {summary.signed_levels} •
+            Breaks: {summary.chain_breaks?.length || 0}
           </p>
         </div>
       )}
-      <div ref={containerRef}>
-        <Graphviz dot={dot} />
+      <div ref={containerRef} className="w-full overflow-auto flex justify-center">
+        <Graphviz dot={dot} style={{ width: "100%", minHeight: "600px" }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make graph card more compact
- left-align the graph header and enlarge the Graphviz output

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68497ffe3644832ea4de6ea57fd7d396