### PR TITLE
Improve graph scale control and chain break styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ export default function App() {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const MAX_DAYS = 1825;
   const [timeline, setTimeline] = useState(MAX_DAYS);
+  const [graphScale, setGraphScale] = useState(1);
   const [loginOpen, setLoginOpen] = useState(true);
   const [signupOpen, setSignupOpen] = useState(false);
 
@@ -327,7 +328,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
                 {tooltipLabel}
               </div>
             </div>
-            <Slider
+          <Slider
               min={0}
               max={MAX_DAYS}
               step={1}
@@ -335,6 +336,19 @@ const [signupMessageType, setSignupMessageType] = useState("");
               onValueChange={(v) => setTimeline(v[0])}
               className="h-full"
             />
+          </div>
+          {/* Scale Slider */}
+          <div className="flex items-center gap-4 mb-6">
+            <span className="text-sm">Scale</span>
+            <Slider
+              min={0.5}
+              max={2}
+              step={0.1}
+              value={[graphScale]}
+              onValueChange={(v) => setGraphScale(v[0])}
+              className="flex-1"
+            />
+            <span className="text-sm w-10 text-right">{graphScale.toFixed(1)}x</span>
           </div>
           {/*rendering card */}
           <div className="relative">
@@ -344,6 +358,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
                   domain={currentDomain}
                   refreshTrigger={refreshTrigger}
                   theme={theme}
+                  scale={graphScale}
                 />
               </CardContent>
             </Card>

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -130,7 +130,13 @@ const SampleGraph = ({ domain, refreshTrigger, theme, scale = 1 }) => {
 
     // Delegation edges between zones
     for (let i = 0; i < data.levels.length - 1; i++) {
-      dotStr += `  apex_${i} -> apex_${i + 1} [label="delegates to" color="#FF9800" style=dashed];\n`;
+      const child = data.levels[i + 1];
+      const broken = child.chain_break_info?.has_chain_break;
+      const color = broken ? "#D32F2F" : "#FF9800";
+      const label = broken ? "delegation (broken)" : "delegates to";
+      const style = broken ? "bold" : "dashed";
+      const pen = broken ? " penwidth=2" : "";
+      dotStr += `  apex_${i} -> apex_${i + 1} [label="${label}" color="${color}" style=${style}${pen}];\n`;
     }
 
     dotStr += '}';


### PR DESCRIPTION
## Summary
- highlight delegation edges when a chain break occurs
- add UI slider to control graph scale
- pass scale prop to `SampleGraph` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bdff1fb0c832e9f1ee1e9343842a5