### PR TITLE
Fix graph rendering for DNSSEC visualizer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,8 @@ export default function App() {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const MAX_DAYS = 1825;
   const [timeline, setTimeline] = useState(MAX_DAYS);
-  const [graphScale, setGraphScale] = useState(1);
+  // Set the scale for the graph rendering. Adjust this value as needed.
+  const GRAPH_SCALE = 1;
   const [loginOpen, setLoginOpen] = useState(true);
   const [signupOpen, setSignupOpen] = useState(false);
 
@@ -337,20 +338,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
               className="h-full"
             />
           </div>
-          {/* Scale Slider */}
-          <div className="flex items-center gap-4 mb-6">
-            <span className="text-sm">Scale</span>
-            <Slider
-              min={0.5}
-              max={2}
-              step={0.1}
-              value={[graphScale]}
-              onValueChange={(v) => setGraphScale(v[0])}
-              className="flex-1"
-            />
-            <span className="text-sm w-10 text-right">{graphScale.toFixed(1)}x</span>
-          </div>
-          {/*rendering card */}
+          {/* rendering card */}
           <div className="relative">
             <Card className="w-full bg-card border-border">
               <CardContent className="relative px-6 py-6 lg:px-8 lg:py-8 flex justify-center overflow-auto">
@@ -358,7 +346,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
                   domain={currentDomain}
                   refreshTrigger={refreshTrigger}
                   theme={theme}
-                  scale={graphScale}
+                  scale={GRAPH_SCALE}
                 />
               </CardContent>
             </Card>

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -49,8 +49,14 @@ const SampleGraph = ({ domain, refreshTrigger, theme, scale = 1 }) => {
       if (level.chain_break_info?.has_chain_break) {
         colors = { border: '#D32F2F', apex: '#D32F2F', apexFill: '#FFCDD2' };
       }
-      const ksk = level.records?.dnskey_records?.find((k) => k.is_ksk);
-      const zsk = level.records?.dnskey_records?.find((k) => k.is_zsk);
+      // Grab the first KSK/ZSK from the records. If none are flagged
+      // fall back to the key_hierarchy lists which are always populated
+      const ksk =
+        level.records?.dnskey_records?.find((k) => k.is_ksk) ||
+        level.key_hierarchy?.ksk_keys?.[0];
+      const zsk =
+        level.records?.dnskey_records?.find((k) => k.is_zsk) ||
+        level.key_hierarchy?.zsk_keys?.[0];
       const kskInfo = ksk
         ? `Key ID ${ksk.key_tag} | Algo ${ksk.algorithm}`
         : '';
@@ -71,9 +77,7 @@ const SampleGraph = ({ domain, refreshTrigger, theme, scale = 1 }) => {
       dotStr += `    apex_${idx} [label="${level.display_name}" shape=rect fillcolor="${colors.apexFill}" color="${colors.apex}"];\n`;
 
       dotStr += `    keyset_${idx} [shape=record fillcolor="#E3F2FD" color="#2196F3" label="{ {<ksk> KSK | ${kskInfo} } | {<zsk> ZSK | ${zskInfo} } }"];\n`;
-      if (idx !== 0) {
-        dotStr += `    dnskey_rrset_${idx} [label="DNSKEY Records" shape=ellipse fillcolor="#BBDEFB" color="#1976D2"];\n`;
-      }
+      dotStr += `    dnskey_rrset_${idx} [label="DNSKEY Records" shape=ellipse fillcolor="#BBDEFB" color="#1976D2"];\n`;
 
       dotStr += `    ds_rrset_${idx} [label="DS Records" shape=ellipse fillcolor="#E1BEE7" color="#8E24AA"];\n`;
 
@@ -95,13 +99,9 @@ const SampleGraph = ({ domain, refreshTrigger, theme, scale = 1 }) => {
         }
       }
 
-      if (idx === 0) {
-        dotStr += `    apex_${idx} -> keyset_${idx}:ksk [label="has DNSKEYs" color="#1976D2"];\n`;
-      } else {
-        dotStr += `    apex_${idx} -> dnskey_rrset_${idx} [label="has" color="#1976D2"];\n`;
-        dotStr += `    dnskey_rrset_${idx} -> keyset_${idx}:ksk [color="#1976D2"];\n`;
-        dotStr += `    dnskey_rrset_${idx} -> keyset_${idx}:zsk [color="#1976D2"];\n`;
-      }
+      dotStr += `    apex_${idx} -> dnskey_rrset_${idx} [label="has" color="#1976D2"];\n`;
+      dotStr += `    dnskey_rrset_${idx} -> keyset_${idx}:ksk [color="#1976D2"];\n`;
+      dotStr += `    dnskey_rrset_${idx} -> keyset_${idx}:zsk [color="#1976D2"];\n`;
       dotStr += `    apex_${idx} -> ds_rrset_${idx} [label="has" color="#8E24AA"];\n`;
       if (idx < data.levels.length - 1) {
         const child = data.levels[idx + 1];
@@ -112,6 +112,9 @@ const SampleGraph = ({ domain, refreshTrigger, theme, scale = 1 }) => {
         if (ds) {
           dotStr +=
             `    ds_rrset_${idx} -> ds_for_${idx}_${idx + 1} [color="#8E24AA"];\n`;
+          // Zone ZSK signs the DS record for the child zone
+          dotStr +=
+            `    keyset_${idx}:zsk -> ds_for_${idx}_${idx + 1} [label="signs" color="#1976D2"];\n`;
           const edgeStyle = childBreak && breakReason.toLowerCase().includes('dnskey')
             ? 'color="#D32F2F" style=dashed'
             : 'color="#4CAF50" penwidth=2';


### PR DESCRIPTION
## Summary
- set a constant graph scale and remove the scale slider
- show root ZSK/KSK when not flagged in DNSKEY records
- include DNSKEY nodes for the root zone
- connect each zone's ZSK to its DS record for the next zone

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685be8e8f180832eb8ba1229090bbfc1