### PR TITLE
Add API base config and Google profile data

### DIFF
--- a/main.py
+++ b/main.py
@@ -697,12 +697,13 @@ def google_auth(payload: TokenPayload):
         )
         email = idinfo.get("email")
         name = idinfo.get("name", email)
+        picture = idinfo.get("picture")
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid token")
 
     for entry in data:
         if len(entry) > 1 and entry[1] == email:
-            return {"success": entry[0], "email": email}
+            return {"success": entry[0], "email": email, "picture": picture}
 
     file_entry = f"{name}:{email}:"
     array_entry = [name, email, ""]
@@ -710,6 +711,6 @@ def google_auth(payload: TokenPayload):
     with open("C:\\Users\\ahmad\\Desktop\\lockedin\\src\\data.txt", "a") as file:
         file.write(f"\n{file_entry}")
 
-    return {"success": name, "email": email}
+    return {"success": name, "email": email, "picture": picture}
     
 #uvicorn main:app --reload

--- a/src/App copy.jsx
+++ b/src/App copy.jsx
@@ -14,6 +14,7 @@ import {
 import Graphviz from "graphviz-react";
 import DNSSECVisualizer from "./DnsGraph2.jsx";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { API_BASE } from "@/lib/api";
 export default function App() {
   // UI state
   const [domain, setDomain] = useState("chatgpt.com");
@@ -44,7 +45,7 @@ export default function App() {
     setLoginError("");
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/login/${loginEmail}/${loginPassword}`
+        `${API_BASE}/login/${loginEmail}/${loginPassword}`
       );
       if (!res.ok) {
         setLoginError("Unable to verify credentials.");
@@ -69,7 +70,7 @@ export default function App() {
     setSignupMessage("");
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/signup/${signupEmail}/${signupPassword}/${signupName}`
+        `${API_BASE}/signup/${signupEmail}/${signupPassword}/${signupName}`
       );
       if (res.ok) {
         setSignupMessageType("success");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import {
 import SampleGraph from "./SampleGraph.jsx";
 import DNSSECVisualizer from "./DNSGraph.jsx";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { API_BASE } from "@/lib/api";
 export default function App() {
   // UI state
   const [domain, setDomain] = useState("");
@@ -28,6 +29,7 @@ export default function App() {
   const [loginPassword, setLoginPassword] = useState("");
   const [loginError, setLoginError] = useState("");
   const [username, setUsername] = useState("");
+  const [profilePic, setProfilePic] = useState(null);
 
   // Theme state
   const [theme, setTheme] = useState("dark");
@@ -71,7 +73,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
 
   const handleGoogleCredential = async (credential) => {
     try {
-      const res = await fetch("http://127.0.0.1:8000/google-auth", {
+      const res = await fetch(`${API_BASE}/google-auth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token: credential }),
@@ -79,6 +81,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
       if (res.ok) {
         const data = await res.json();
         setUsername(data.success);
+        setProfilePic(data.picture || null);
         setLoginOpen(false);
         setSignupOpen(false);
       }
@@ -91,7 +94,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
     setLoginError("");
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/login/${loginEmail}/${loginPassword}`
+        `${API_BASE}/login/${loginEmail}/${loginPassword}`
       );
       if (!res.ok) {
         setLoginError("Unable to verify credentials.");
@@ -101,6 +104,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
       const successVal = data.success.trim();
       if (successVal !== "no") {
         setUsername(successVal);
+        setProfilePic(null);
         setLoginError("");
         setLoginOpen(false);
       } else {
@@ -115,7 +119,7 @@ const [signupMessageType, setSignupMessageType] = useState("");
     setSignupMessage("");
     try {
       const res = await fetch(
-        `http://127.0.0.1:8000/signup/${signupEmail}/${signupPassword}/${signupName}`
+        `${API_BASE}/signup/${signupEmail}/${signupPassword}/${signupName}`
       );
       if (res.ok) {
         setSignupMessageType("success");
@@ -283,7 +287,15 @@ const [signupMessageType, setSignupMessageType] = useState("");
             DNS Chain Visualizer
           </h1>
           <div className="flex items-center space-x-2">
-            <User className="h-6 w-6 text-foreground" />
+            {profilePic ? (
+              <img
+                src={profilePic}
+                alt={username}
+                className="h-8 w-8 rounded-full"
+              />
+            ) : (
+              <User className="h-6 w-6 text-foreground" />
+            )}
             <p className="text-lg text-foreground">{username}</p>
             <Button size="icon" variant="secondary" onClick={toggleTheme}>
               {theme === "dark" && <div className="text-primary">🌙</div>}

--- a/src/DNSGraph.jsx
+++ b/src/DNSGraph.jsx
@@ -18,6 +18,7 @@ import {
   CheckCircle,
   XCircle,
 } from "lucide-react";
+import { API_BASE } from "@/lib/api";
 
 // Sample data for fallback/demo purposes
 const sampleData = {
@@ -130,9 +131,8 @@ function DNSSECVisualizer({ domain, onRefresh, refreshTrigger }) {
       setLoading(true);
       setError(null);
 
-      // Replace with your actual API endpoint
       const response = await fetch(
-        `http://127.0.0.1:8000/chain/${encodeURIComponent(domain)}`
+        `${API_BASE}/chain/${encodeURIComponent(domain)}`
       );
 
       if (!response.ok) {

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -3,6 +3,7 @@ import Graphviz from "graphviz-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { RotateCcw } from "lucide-react";
+import { API_BASE } from "@/lib/api";
 
 /**
  * Renders a DNSSEC chain as a Graphviz diagram.
@@ -162,7 +163,7 @@ const SampleGraph = ({ domain, refreshTrigger, theme, onRefresh }) => {
     try {
       setLoading(true);
       const res = await fetch(
-        `http://127.0.0.1:8000/chain/${encodeURIComponent(domain)}`
+        `${API_BASE}/chain/${encodeURIComponent(domain)}`
       );
       const json = await res.json();
       setDot(buildDot(json));

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || "";


### PR DESCRIPTION
## Summary
- return user profile pictures from Google auth
- consume API base URL from `VITE_API_BASE`
- display Google profile picture in header after login
- update fetch calls to use API base URL

## Testing
- `npm run lint` *(fails: cannot find some packages / lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68625758a914832e99111ee202e9cc82